### PR TITLE
fix(vaultCard): make card heights consistent regardless of balance

### DIFF
--- a/components/vaultCard/vaultCard.module.css
+++ b/components/vaultCard/vaultCard.module.css
@@ -2,6 +2,7 @@
   width: 100%;
   border-radius: 10px;
   cursor: pointer;
+  min-height: 213px;
 }
 
 .vaultContainerActive {
@@ -10,6 +11,7 @@
   cursor: pointer;
   background: rgb(63,94,251);
   background: radial-gradient(circle, rgba(63,94,251,0.7) 0%, rgba(47,128,237,0.7) 48%) rgba(63,94,251,0.7) 100%;
+  min-height: 213px;
 }
 
 .vaultTitle {
@@ -88,6 +90,16 @@
 
 @media screen and (max-width: 1440px) {
 
+}
+
+@media screen and (max-width: 1000px) {
+  .vaultContainer {
+    min-height: 0;
+  }
+  
+  .vaultContainerActive {
+    min-height: 0;
+  }
 }
 
 @media screen and (max-width: 576px) {


### PR DESCRIPTION
Hey folks, got an unsolicited PR here, won't be offended if y'all choose to ignore, especially since it's a tad hacky.

On desktop, cards for vaults with balances are vertically shorter than their zero-balance counterparts. Their feet don't reach the floor:

<img width="1149" alt="Screen Shot 2021-04-27 at 1 32 38 PM" src="https://user-images.githubusercontent.com/31059979/116287469-749ad280-a75e-11eb-8470-feb7997ba8f9.png">


To fix that I set a min-height on desktop (tablet/mobile view is unaffected):

<img width="1150" alt="Screen Shot 2021-04-27 at 1 32 21 PM" src="https://user-images.githubusercontent.com/31059979/116287480-782e5980-a75e-11eb-9b9f-bff61c15440a.png">

Lmk what y'all think, happy to take a different approach or tackle a more important issue (just getting my feet wet).
