### PR TITLE
feat(vaultCard): add token balance

### DIFF
--- a/components/vaultCard/vaultCard.js
+++ b/components/vaultCard/vaultCard.js
@@ -62,11 +62,14 @@ export default function VaultCard({ vault, account }) {
           {activeVault && (
             <div className={classes.vaultInfoField}>
               <Typography variant="h2" className={classes.fontWeightBold}>
-                { !(vault && vault.balance) && <Skeleton /> }
-                { (vault && vault.balance && vault.type === 'Lockup') && formatCurrency(vault.balance) + ' ' + vault.symbol }
-                { (vault && vault.balanceUSD && vault.type !== 'Lockup') && '$ ' + formatCurrency(vault.balanceUSD) }
+                {!(vault && vault.balance) && <Skeleton />}
+                {vault && vault.balanceUSD && vault.type !== 'Lockup' && '$ ' + formatCurrency(vault.balanceUSD)}
               </Typography>
-              <Typography variant="body1">Balance</Typography>
+              <Typography variant="h2" className={classes.fontWeightBold}>
+                {!(vault && vault.balance) && <Skeleton />}
+                {vault && vault.balance && formatCurrency(vault.balance) + ' ' + vault.displayName}
+              </Typography>
+              <Typography variant="h2">Balance</Typography>
             </div>
           )}
           {!activeVault && account && account.address && (
@@ -78,14 +81,14 @@ export default function VaultCard({ vault, account }) {
                   formatCurrency(vault.tokenMetadata.balance) + ' ' + vault.tokenMetadata.displayName
                 )}
               </Typography>
-              <Typography variant="body1">Available to deposit</Typography>
+              <Typography variant="h2">Available to deposit</Typography>
             </div>
           )}
-          <div className={classes.vaultInfoField}>
+          <div className={classes.vaultInfoFieldSlim}>
             <Typography variant="h2" className={classes.fontWeightBold}>
               {!vault.apy ? <Skeleton /> : vault.apy.recommended ? BigNumber(vault.apy.recommended).times(100).toFixed(2) + '%' : 'Unknown'}
             </Typography>
-            <Typography variant="body1">Yearly Growth</Typography>
+            <Typography variant="h2">Yearly Growth</Typography>
           </div>
         </div>
       </Paper>

--- a/components/vaultCard/vaultCard.module.css
+++ b/components/vaultCard/vaultCard.module.css
@@ -2,7 +2,7 @@
   width: 100%;
   border-radius: 10px;
   cursor: pointer;
-  min-height: 213px;
+  min-height: 223px;
 }
 
 .vaultContainerActive {
@@ -11,7 +11,7 @@
   cursor: pointer;
   background: rgb(63,94,251);
   background: radial-gradient(circle, rgba(63,94,251,0.7) 0%, rgba(47,128,237,0.7) 48%) rgba(63,94,251,0.7) 100%;
-  min-height: 213px;
+  min-height: 223px;
 }
 
 .vaultTitle {
@@ -98,6 +98,10 @@
 }
 
 @media screen and (max-width: 1000px) {
+
+}
+
+@media screen and (max-width: 600px) {
   .vaultContainer {
     min-height: 0;
   }
@@ -105,8 +109,4 @@
   .vaultContainerActive {
     min-height: 0;
   }
-}
-
-@media screen and (max-width: 576px) {
-
 }

--- a/components/vaultCard/vaultCard.module.css
+++ b/components/vaultCard/vaultCard.module.css
@@ -39,6 +39,11 @@
 }
 
 .vaultInfoField {
+  padding-right: 10px;
+}
+
+.vaultInfoFieldSlim {
+  width: 30%;
 }
 
 .vaultVersionContainer {


### PR DESCRIPTION
Closes https://github.com/antonnell/yearn-finance/issues/33

Add token (DAI, crvSTETH, etc) balances to active vaults in addition to USD. Some screenies:

<img width="588" alt="Screen Shot 2021-04-29 at 1 18 34 AM" src="https://user-images.githubusercontent.com/31059979/116505437-e0795a00-a888-11eb-8c5a-b5ae3fea2f42.png">
<img width="993" alt="Screen Shot 2021-04-29 at 1 16 31 AM" src="https://user-images.githubusercontent.com/31059979/116505444-e3744a80-a888-11eb-8188-a7bacae2d2bb.png">
<img width="629" alt="Screen Shot 2021-04-29 at 1 16 16 AM" src="https://user-images.githubusercontent.com/31059979/116505450-e5d6a480-a888-11eb-92a9-bd080f522b43.png">

This uneven card height thing is a problem again. Could make it `min-height: 255px` or something like that, but then the cards would always be ... pretty tall. I don't have a better solution than min-height handy so up to you:

<img width="1147" alt="Screen Shot 2021-04-29 at 1 18 14 AM" src="https://user-images.githubusercontent.com/31059979/116505441-e2431d80-a888-11eb-8e4d-11ac781c3410.png">
