### PR TITLE
feat(accounts): show error if wallet connected to unsupported chain

### DIFF
--- a/pages/invest/index.js
+++ b/pages/invest/index.js
@@ -63,6 +63,7 @@ function Invest({ changeTheme }) {
   const storePortfolioGrowth = stores.investStore.getStore('portfolioGrowth');
   const storeHighestHoldings = stores.investStore.getStore('highestHoldings');
   const account = stores.accountStore.getStore('account');
+  const chainInvalid = stores.accountStore.getStore('chainInvalid');
 
   const localStorageCoinTypes = localStorage.getItem('yearn.finance-invest-coin-types');
   const localStoragelayout = localStorage.getItem('yearn.finance-invest-layout');
@@ -592,6 +593,12 @@ function Invest({ changeTheme }) {
             </div>
           </Paper>
         </div>
+
+        {chainInvalid ? (
+          <div className={classes.chainInvalidError}>
+            The chain you're connected to isn't supported. Please check that your wallet is connected to ethereum.
+          </div>
+        ) : null}
 
         <div className={classes.vaultsContainer}>
           <div className={classes.vaultFilters}>

--- a/pages/invest/invest.module.css
+++ b/pages/invest/invest.module.css
@@ -404,3 +404,16 @@
   font-size: 20px;
   font-weight: bold;
 }
+
+.chainInvalidError {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex: 1;
+  margin-top: 24px;
+  padding: 36px;
+  width: 100%;
+  flex-wrap: wrap;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.32);
+  background: #dc3545;
+}


### PR DESCRIPTION
Closes #35 

When a user's wallet is connected to an unsupported chain (eg, Fantom), the page just keeps trying to load with no feedback for the user about what's wrong.

Let's stop trying to load account data and show an error instead:

<img width="1079" alt="Screen Shot 2021-05-07 at 12 03 41 AM" src="https://user-images.githubusercontent.com/31059979/117397397-0d052580-aeca-11eb-8077-d5bbcf6f87f3.png">


To test:

- switch MetaMask to a non-ethereum chain, refresh
- see error message
- switch to ethereum mainnet, refresh
- no error


Open questions:

- design, copy: did my best 🤷‍♂️
- placement: currently only on `invest`, should maybe be higher up on the page
- allowed chains: i went by `supportedChainIds` [here](https://github.com/antonnell/yearn-finance/blob/80100f20780fe3bd131706ddfd0ddac6b9af298b/stores/connectors/connectors.js#L23), not sure if that'll mess up people running a local node?


PS - sorry about the diffs, looks like prettier got added after the last edit to `accountsStore`. i added comments where there are real diffs
