### PR TITLE
Fix top vault performers name showing up as `undefined`

### DIFF
--- a/pages/invest/index.js
+++ b/pages/invest/index.js
@@ -118,6 +118,8 @@ function Invest({ changeTheme }) {
         if (v.address.toLowerCase() === vault.address.toLowerCase()) {
           v.apy = vault.apy?.recommended;
           v.nonLowerCaseAddress = vault.address;
+          v.symbol = vault.symbol;
+          v.label = vault.displayName;
         }
         if(v.apy === 'New') {
           v.apy = 0
@@ -475,7 +477,7 @@ function Invest({ changeTheme }) {
                           }}
                           className={classes.topVaultPerformersLink}
                         >
-                          {vault.symbol.split(' Vault')[0]} {(vault.apy * 100).toFixed(2)}%{' '}
+                          {`${vault.label} (${vault.version})`} {(vault.apy * 100).toFixed(2)}%{' '}
                         </span>
                         <HelpIcon
                           style={{ cursor: 'pointer', width: 15 }}
@@ -521,7 +523,7 @@ function Invest({ changeTheme }) {
                           }}
                           className={classes.topVaultPerformersLink}
                         >
-                          {vault.symbol.split(' Vault')[0]} {(vault.apy * 100).toFixed(2)}%{' '}
+                          {`${vault.label} (${vault.version})`} {(vault.apy * 100).toFixed(2)}%{' '}
                         </span>
                         <HelpIcon
                           style={{ cursor: 'pointer', width: 15 }}
@@ -568,7 +570,7 @@ function Invest({ changeTheme }) {
                             }}
                             className={classes.topVaultPerformersLink}
                           >
-                            {vault.symbol.split(' Vault')[0]} {(vault.apy * 100).toFixed(2)}%{' '}
+                            {`${vault.label} (${vault.version})`} {(vault.apy * 100).toFixed(2)}%{' '}
                           </span>
                           <HelpIcon
                             style={{ cursor: 'pointer', width: 15 }}


### PR DESCRIPTION
Copying the name and symbol from the yEarn vault data to fix the top performers names showing up as `undefined`. 

I decided to include the version to avoid ambiguities.

Not sure if this is the best way to fix this, but it seems to work.

<img width="1286" alt="Screen Shot 2021-06-08 at 10 48 27 PM" src="https://user-images.githubusercontent.com/749244/121300399-a5b50980-c8ab-11eb-852a-e676a45489c3.png">

This fixes #49.