### PR TITLE
Add description for Convex vault strategies

### DIFF
--- a/components/vaultStrategyCard/vaultStrategyCard.js
+++ b/components/vaultStrategyCard/vaultStrategyCard.js
@@ -77,6 +77,8 @@ export default function vaultStrategyCard({ strategy, vault }) {
       return `Supplies ${tokens} to KeeperDAO to farm ROOK. Rewards are harvested, sold for more ${tokens}, and deposited back into the vault.`
     } else if (name.includes('StrategySynthetixSusdMinter')) {
       return `Stakes SNX at Synthetix to mint sUSD. The newly minted sUSD is then deposited into the v2 sUSD yVault to earn yield. Yield from sUSD and rewards from weekly fees plus vested rewards (when claimable) are swapped for more SNX and re-deposited into the vault.`
+    } else if (name.includes('Convex')) {
+      return `Supplies ${tokens} to Convex Finance to farm CVX. Rewards are harvested, sold for more ${tokens}, and deposited back into the vault.`
     }
 
     else {


### PR DESCRIPTION
Some vaults are missing strategy descriptions for strategies involving Convex.

<img width="1234" alt="Screen Shot 2021-06-08 at 11 18 38 PM" src="https://user-images.githubusercontent.com/749244/121303381-dc8d1e80-c8af-11eb-9597-bc9ee674e976.png">

This adds the missing descriptions (taken from https://medium.com/yearn-state-of-the-vaults/the-vaults-at-yearn-9237905ffed3)

<img width="1235" alt="Screen Shot 2021-06-08 at 11 18 56 PM" src="https://user-images.githubusercontent.com/749244/121303423-e747b380-c8af-11eb-856e-cc73795345a2.png">
