### PR TITLE
refactor: temporarily update API endpoint

### DIFF
--- a/stores/constants/constants.js
+++ b/stores/constants/constants.js
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 
 // URLS
 export const YEARN_API = 'https://api.yearn.tools/';
-export const YEARN_VAULTS_API = 'https://api.yearn.finance/v1/chains/1/vaults/all';
+export const YEARN_VAULTS_API = 'https://yearn-static-api.s3.amazonaws.com/v1/chains/1/vaults/all';
 export const GAS_PRICE_API = 'https://gasprice.poa.network/';
 export const ZAPPER_GAS_PRICE_API = 'https://api.zapper.fi/v1/gas-price?api_key=96e0cc51-a62e-42ca-acee-910ea7d2a241';
 export const ETHERSCAN_URL = 'https://etherscan.io/';


### PR DESCRIPTION
We published v1 of the yearn.finance API last week.
The new API utilized IPFS/IPNS to push API updates.
Though this is nice in theory in practice this caused a lot of problems.
We're in the process of moving from IPFS to AWS s3 buckets for API snapshots.
Currently we are in a holding pattern with AWS support team that is blocking us from being able to redeploy the API using s3 buckets.

To keep yearn.finance and yearn.fi APY consistent I've submitted a pull request to change the APY API
from:
https://api.yearn.finance/v1/chains/1/vaults/all
to:
https://yearn-static-api.s3.amazonaws.com/v1/chains/1/vaults/all

Once the AWS issues is resolved I will submit a pull request to revert the API endpoint back to the api.yearn.finace endpoint.