### PR TITLE
feat: display vault tokens to receive (v2 support)

### DIFF
--- a/components/vaultActionCard/deposit.js
+++ b/components/vaultActionCard/deposit.js
@@ -39,6 +39,7 @@ export default function Deposit({ vault }) {
   const [zapperBalanceTokens, setZapperBalanceTokens] = useState([]);
   const [currentToken, setCurrentToken] = useState();
   const [zapperBalanceUpdated, setZapperBalanceUpdated] = useState(false);
+  const [sharesForAmount, setSharesForAmount] = useState(0.00); // vault tokens to receive upon deposit
 
   const handleZapperSlippage = (event, slippage) => {
     if (slippage === 0.01 || slippage === 0.02 || slippage === 0.03) setZapperSlippage(slippage);
@@ -218,6 +219,30 @@ export default function Deposit({ vault }) {
       fetchAccountBalanceFromZapper();
     }
   }, []);
+
+  useEffect(() => {
+    function setVaultTokenSharesForAmount() {
+      let tokenAmount;
+      // support for only v2 in the mean time
+      if (vault.type === 'v2') {
+        zapperVaults.map(zvault => {
+          if (zvault.address.toLowerCase() === vault.address.toLowerCase()) {
+            if (currentToken.address?.toLowerCase() !== vault.tokenMetadata?.address?.toLowerCase()) {
+              tokenAmount = (amount * currentToken.price) / zvault.pricePerToken;
+            } else {
+              tokenAmount = amount;
+            }
+          }
+        }); 
+        if (vault.pricePerFullShare > 0) {
+          setSharesForAmount(BigNumber(tokenAmount).div(vault.pricePerFullShare))
+        } else {
+          setSharesForAmount(tokenAmount);
+        }
+      } 
+    }
+    setVaultTokenSharesForAmount();
+  }, [amount]);
 
   let depositDisabled = false
   let depositDisabledMessage = null
@@ -418,6 +443,17 @@ export default function Deposit({ vault }) {
           </div>
         </div>
       )}
+      {
+        vault.type === 'v2' && amount !== '' && (
+          <div className={classes.inputTitleContainer}>
+            <div className={classes.depositSharesAmount}>
+              <Typography variant="h5" className={classes.value} noWrap>
+                {`To Receive: ${formatCurrency(sharesForAmount)} ${vault.symbol}`}
+              </Typography>
+            </div>
+          </div>
+        )
+      }
       {(!account || !account.address) && (
         <div className={classes.actionButton}>
           <Button fullWidth disableElevation variant="contained" color="primary" size="large" onClick={onConnectWallet} disabled={loading}>

--- a/components/vaultActionCard/vaultActionCard.module.css
+++ b/components/vaultActionCard/vaultActionCard.module.css
@@ -162,3 +162,12 @@
 .slippageText {
   width: 40px;
 }
+
+.depositSharesAmount {
+  margin-top: 25px;
+  margin-left: 12px;
+  display: flex;
+  flex-direction: row;
+  width: 100%;
+  justify-content: space-between;
+}


### PR DESCRIPTION
displaying vault tokens account will receive after successful deposit

support for v2 as at now

chose to useEffect() only when amount changes. depending on onAmountChanged & setAmountPercent proved
inconsistent

see todos