### PR TITLE
fix: change yearn vaults api url

### DIFF
--- a/stores/constants/constants.js
+++ b/stores/constants/constants.js
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 
 // URLS
 export const YEARN_API = 'https://api.yearn.tools/';
-export const YEARN_VAULTS_API = 'https://yearn-static-api.s3.amazonaws.com/v1/chains/1/vaults/all';
+export const YEARN_VAULTS_API = 'https://api.yearn.finance/v1/chains/1/vaults/all';
 export const GAS_PRICE_API = 'https://gasprice.poa.network/';
 export const ZAPPER_GAS_PRICE_API = 'https://api.zapper.fi/v1/gas-price?api_key=96e0cc51-a62e-42ca-acee-910ea7d2a241';
 export const ETHERSCAN_URL = 'https://etherscan.io/';


### PR DESCRIPTION
Raw S3 url is going to be deprecated soon. Change is live on yearn.finance as of https://github.com/yearn/yearn-finance/commit/a42631f9f9783c354091d8ec071ddf9e806fdcb4.